### PR TITLE
use non-LTO IPO cflags, adjust ldflags for Identical Code Folding and…

### DIFF
--- a/rpm/user/openmandriva/macros
+++ b/rpm/user/openmandriva/macros
@@ -110,7 +110,7 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
 
 # When LTOing, it is useful to duplicate CFLAGS in LDFALGS
 # See https://github.com/OpenMandrivaSoftware/rpm-openmandriva-setup/pull/3
-%build_ldflags %{optflags} -Wl,-O2 %{?!_disable_ld_no_undefined: -Wl,--no-undefined} %{?!_disable_lto:-flto} %{?_hardened_flags}
+%build_ldflags %{optflags} -Wl,-O2 %{?!_disable_ld_no_undefined: -Wl,--no-undefined} %{?!_disable_lto:-flto} %{?_hardened_flags} %{?!_disable_icf:-Wl,--icf=all} %{?!_disable_ipo:-Wl,--gc-sections}
 
 # Deprecated names.  For backwards compatibility only.
 %ldflags %build_ldflags
@@ -156,8 +156,11 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
 # cf http://wiki.mandriva.com/en/Development/Packaging/Problems#format_not_a_string_literal_and_no_format_arguments
 %Werror_cflags -Wformat -Werror=format-security
 
+# use non-LTO interprocedural optimization
+%ipo_cflags -ffunction-sections -fdata-sections
+
 %_ssp_cflags -fstack-protector-all --param=ssp-buffer-size=4
-%__common_cflags -Os -fomit-frame-pointer %{debugcflags} -pipe %{Werror_cflags} %{?_fortify_cflags}
+%__common_cflags -Os -fomit-frame-pointer %{debugcflags} -pipe %{Werror_cflags} %{?_fortify_cflags} %{?!_disable_ipo: %ipo_cflags}
 %__common_cflags_with_ssp %{__common_cflags} %{?_ssp_cflags}
 
 # Servers opt flags.


### PR DESCRIPTION
use non-LTO IPO cflags, adjust ldflags for Identical Code Folding and function Garbage Collector

Here is the long story short:
1. lld has a hardcoded options in a patch:
 --icf=safe
 --gc-sections
2. There are some software that intentionally does not use of {C,LD}FLAGS and this means above hardcoded flags can not be overrided by:
 - exporting LDFLAGS or redifining %build_ldfags
 - patching source files to and opposite options that disables above flags
3. lld --icf=safe implementation is diffrent from ld.bfd!
- This thread casts some light on it https://www.spinics.net/lists/linux-efi/msg19229.html
- hardcoded --icf=safe in lld breaks kernel, vmlinux is missing symbols 
- https://github.com/ClangBuiltLinux/linux/issues/1341
- chromeos uses --icf=all and they claim this one is safe https://bugs.chromium.org/p/chromium/issues/detail?id=576197
4. Function Garbage Collector break things when upstream wants to keep specific input sections:
- see PE/COFF files (see vmlinux)
- This says -gc-sections is experimental https://sourceware.org/binutils/docs/ld/Options.html
- https://github.com/ClangBuiltLinux/linux/issues/1336
5. Using --gc-sections without `-ffunction-sections -fdata-sections` makes only half of the success

I did compile llvm without above hardcodes:
https://github.com/OpenMandrivaAssociation/llvm/pull/12
then i build kernel-release for x86_64 and aarch64. Both kernels clang flovours uses lld as default linker.
x86_64: https://abf.openmandriva.org/build_lists/40029
aarch64: https://abf.openmandriva.org/build_lists/40016

```
[root@tpg-latitude5490 tpg]# uptime
 18:15:31 up 44 min,  4 users,  load average: 0,44, 0,39, 0,36
[root@tpg-latitude5490 tpg]# uname -a
Linux tpg-latitude5490 5.11.13-desktop-clang-1omv4050 #1 SMP PREEMPT Tue Apr 13 13:10:26 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
[root@tpg-latitude5490 tpg]# grep LLD /boot/config-5.11.13-desktop-clang-1omv4050 
CONFIG_LD_IS_LLD=y
CONFIG_LLD_VERSION=120000
```
