### PR TITLE
Add 'iocharset' to efi mount options

### DIFF
--- a/installer/mount.conf
+++ b/installer/mount.conf
@@ -58,7 +58,7 @@ mountOptions:
       options: [ defaults, noatime ]
       ssdOptions: [ discard ]
     - filesystem: efi
-      options: [ defaults, noatime, umask=0077 ]
+      options: [ defaults, noatime, umask=0077, iocharset=iso8859-1 ]
     - filesystem: ext4
       options: [ defaults, noatime ]
       ssdOptions: [ discard ]


### PR DESCRIPTION
Add 'iocharset=iso8859-1' to override the default 'iocharset=utf8', _only for EFI mounts_. This fixes the issue #3085.