### PR TITLE
make autologin show again

### DIFF
--- a/installer/users.conf
+++ b/installer/users.conf
@@ -21,6 +21,7 @@ defaultGroups:
 
 autologinGroup:  autologin
 doAutologin:     false
+displayAutologin:   true
 sudoersGroup:    wheel
 sudoersConfigureWithGroup: false
 setRootPassword: true


### PR DESCRIPTION
fixes the missing user autologin option in calamares.